### PR TITLE
Add Fixed Length Passcode Example

### DIFF
--- a/examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode.tsx
+++ b/examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode.tsx
@@ -24,7 +24,7 @@ const makeStyles = (): StyleSheet.NamedStyles<{
             marginBottom: 32,
         },
         topDivider: {
-            marginTop: 24,
+            marginTop: 40,
             marginBottom: 32,
             marginHorizontal: -16,
         },

--- a/examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode.tsx
+++ b/examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode.tsx
@@ -137,7 +137,6 @@ export const FixedLengthPasscodeScreen: React.FC = () => {
                                 label="Passcode *"
                                 value={passcode}
                                 onChangeText={onPasscodeChange}
-                                returnKeyType={'next'}
                                 keyboardType={'numeric'}
                                 error={passcodeErrorText !== ''}
                                 errorText={passcodeErrorText}

--- a/examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode.tsx
+++ b/examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode.tsx
@@ -1,0 +1,176 @@
+import React, { useCallback, useState } from 'react';
+import { Body1, Header, wrapIcon } from '@pxblue/react-native-components';
+import { View, StyleSheet, ScrollView, ViewStyle, TextStyle, SafeAreaView } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import { DrawerNavigationProp } from '@react-navigation/drawer';
+import { TextInput } from '../shared/TextInput';
+import { ActivityIndicator, Button, Divider } from 'react-native-paper';
+import * as Colors from '@pxblue/colors';
+
+const MenuIcon = wrapIcon({ IconClass: MaterialIcons, name: 'menu' });
+const RefreshIcon = wrapIcon({ IconClass: MaterialIcons, name: 'refresh' });
+const DoneIcon = wrapIcon({ IconClass: MaterialIcons, name: 'done' });
+
+const makeStyles = (): StyleSheet.NamedStyles<{
+    section: ViewStyle;
+    topDivider: ViewStyle;
+    passcodeFormFieldWrapper: TextStyle;
+    passcodeErrorFormFieldWrapper: TextStyle;
+    resetFormButton: ViewStyle;
+}> =>
+    StyleSheet.create({
+        section: {
+            padding: 16,
+            marginBottom: 32,
+        },
+        topDivider: {
+            marginTop: 24,
+            marginBottom: 32,
+            marginHorizontal: -16,
+        },
+        passcodeFormFieldWrapper: {
+            marginBottom: 24.5,
+        },
+        passcodeErrorFormFieldWrapper: {
+            marginBottom: 0,
+        },
+        resetFormButton: {
+            marginTop: 16
+        },
+    });
+
+export const FixedLengthPasscodeScreen: React.FC = () => {
+    const navigation = useNavigation<DrawerNavigationProp<Record<string, undefined>>>();
+    const styles = makeStyles();
+    const [passcode, setPasscode] = useState('');
+    const [passcodeErrorText, setPasscodeErrorText] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+    const [passcodeSubmitted, setPasscodeSubmitted] = useState(false);
+    const [passcodeSuccess, setPasscodeSuccess] = useState(false);
+
+    const toggleMenu = (): void => {
+        navigation.openDrawer();
+    };
+
+    const validatePasscode = useCallback(
+        (value: string): void => {
+            const tempPasscode = value;
+            let tempPasscodeError = '';
+            if (!tempPasscode.trim()) {
+                tempPasscodeError = 'Please enter a six-digit-passcode';
+            }
+            if (passcodeSubmitted && !passcodeSuccess) {
+                tempPasscodeError = 'Invalid Passcode';
+            }
+            setPasscodeErrorText(tempPasscodeError);
+        },
+        [setPasscodeErrorText]
+    );
+
+    const verifyPasscode = (text: string): void => {
+        // eslint-disable-next-line no-console
+                console.log(text);
+        setIsLoading(true);
+        setTimeout((): void => {
+            if (passcode === '123456') {
+                 // eslint-disable-next-line no-console
+                console.log('setting to true');
+                setPasscodeSuccess(true);
+            }
+            setPasscodeSubmitted(true);
+            setIsLoading(false);
+            validatePasscode(text);
+        }, 3000);
+    };
+
+    const onPasscodeChange = useCallback(
+        (text: string) => {
+            setPasscode(text);
+            validatePasscode(text);
+
+            if (text.length === 6) {
+                verifyPasscode((text));
+            }
+        },
+        [setPasscode, validatePasscode]
+    );
+
+    const onPasscodeBlur = useCallback((): void => {
+        validatePasscode(passcode);
+    }, [validatePasscode, passcode]);
+
+    // const getPasscodeRightIcon = useCallback((): React.ReactNode => {
+    //     if (isLoading) {
+    //         return <ActivityIndicator animating={true} color={Colors.blue[500]} size={20} />;
+    //     }
+    //     if (!isLoading && passcodeSubmitted && passcodeSuccess) {
+    //         return <DoneIcon color={Colors.green[500]} size={20} />;
+    //     }
+    // }, [isLoading, passcodeSubmitted, passcodeSuccess]);
+
+    const resetForm = (): void => {
+        setPasscode('');
+        setPasscodeErrorText('');
+        setPasscodeSubmitted(false);
+        setPasscodeSuccess(false);
+    }
+
+    return (
+        <View style={{ flex: 1 }}>
+            <Header
+                title={'Fixed Length Passcode'}
+                navigation={{
+                    icon: MenuIcon,
+                    onPress: (): void => {
+                        toggleMenu();
+                    },
+                }}
+            />
+            <SafeAreaView>
+                <ScrollView>
+                    <View style={styles.section}>
+                        <Body1>
+                            Please enter the <Body1 font={'medium'}>six-digit passcode</Body1> we just send to you. The
+                            passcode is valid for 15 minutes.
+                        </Body1>
+                        <Body1 style={{ marginTop: 8 }}>
+                            For the purpose of this demonstration, passcode <Body1 font={'medium'}>123456</Body1> will
+                            pass. Any other 6 digit passcode will fail.
+                        </Body1>
+                        <Divider style={styles.topDivider} />
+                        <View
+                            style={
+                                passcodeErrorText !== ''
+                                    ? styles.passcodeErrorFormFieldWrapper
+                                    : styles.passcodeFormFieldWrapper
+                            }
+                        >
+                            <TextInput
+                                label="Passcode *"
+                                value={passcode}
+                                onChangeText={onPasscodeChange}
+                                returnKeyType={'next'}
+                                keyboardType={'numeric'}
+                                error={passcodeErrorText !== ''}
+                                errorText={passcodeErrorText}
+                                onBlur={onPasscodeBlur}
+                                rightIcon={isLoading ? <ActivityIndicator animating={true} color={Colors.blue[500]} size={20} /> : !isLoading && passcodeSubmitted && passcodeSuccess ? <DoneIcon color={Colors.green[500]} size={20} /> : <></>}
+                                maxLength={6}
+                                disabled={isLoading || (passcodeSubmitted && passcodeSuccess)}
+                            />
+                        </View>
+                        <Button
+                            mode="outlined"
+                            style={styles.resetFormButton}
+                            onPress={resetForm}
+                            icon={(): JSX.Element => <RefreshIcon color={Colors.blue[500]} size={24} />}
+                        >
+                            Reset Form
+                        </Button>
+                    </View>
+                </ScrollView>
+            </SafeAreaView>
+        </View>
+    );
+};

--- a/examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode.tsx
+++ b/examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode.tsx
@@ -53,17 +53,14 @@ export const FixedLengthPasscodeScreen: React.FC = () => {
         navigation.openDrawer();
     };
 
-    const validatePasscode = useCallback(
-        (value: string): void => {
-            const tempPasscode = value;
-            let tempPasscodeError = '';
-            if (tempPasscode.trim().length < 6) {
-                tempPasscodeError = 'Please enter a six-digit-passcode';
-            }
-            setPasscodeErrorText(tempPasscodeError);
-        },
-        [setPasscodeErrorText]
-    );
+    const validatePasscode = useCallback((value: string): void => {
+        const tempPasscode = value;
+        let tempPasscodeError = '';
+        if (tempPasscode.trim().length < 6) {
+            tempPasscodeError = 'Please enter a six-digit-passcode';
+        }
+        setPasscodeErrorText(tempPasscodeError);
+    }, []);
 
     const verifyPasscode = (text: string): void => {
         setPasscodeErrorText('');
@@ -87,13 +84,13 @@ export const FixedLengthPasscodeScreen: React.FC = () => {
             if (shouldValidate) validatePasscode(text);
             if (text.length === 6) verifyPasscode(text);
         },
-        [setPasscode, validatePasscode, shouldValidate, verifyPasscode]
+        [validatePasscode, shouldValidate, verifyPasscode]
     );
 
     const onPasscodeBlur = useCallback((): void => {
         setShouldValidate(true);
         validatePasscode(passcode);
-    }, [setShouldValidate, validatePasscode, passcode]);
+    }, [validatePasscode, passcode]);
 
     const resetForm = (): void => {
         setPasscode('');

--- a/examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode.tsx
+++ b/examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Body1, Header, wrapIcon } from '@pxblue/react-native-components';
-import { View, StyleSheet, ScrollView, ViewStyle, TextStyle, SafeAreaView, Dimensions } from 'react-native';
+import { View, StyleSheet, ScrollView, ViewStyle, SafeAreaView, Dimensions } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { DrawerNavigationProp } from '@react-navigation/drawer';
@@ -15,8 +15,8 @@ const makeStyles = (): StyleSheet.NamedStyles<{
     section: ViewStyle;
     sectionTablet: ViewStyle;
     topDivider: ViewStyle;
-    passcodeFormFieldWrapper: TextStyle;
-    passcodeErrorFormFieldWrapper: TextStyle;
+    passcodeFormFieldWrapper: ViewStyle;
+    passcodeErrorFormFieldWrapper: ViewStyle;
     resetFormButton: ViewStyle;
 }> =>
     StyleSheet.create({

--- a/examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode.tsx
+++ b/examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Body1, Header, wrapIcon } from '@pxblue/react-native-components';
-import { View, StyleSheet, ScrollView, ViewStyle, TextStyle, SafeAreaView } from 'react-native';
+import { View, StyleSheet, ScrollView, ViewStyle, TextStyle, SafeAreaView, Dimensions } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { DrawerNavigationProp } from '@react-navigation/drawer';
@@ -13,6 +13,7 @@ const RefreshIcon = wrapIcon({ IconClass: MaterialIcons, name: 'refresh' });
 
 const makeStyles = (): StyleSheet.NamedStyles<{
     section: ViewStyle;
+    sectionTablet: ViewStyle;
     topDivider: ViewStyle;
     passcodeFormFieldWrapper: TextStyle;
     passcodeErrorFormFieldWrapper: TextStyle;
@@ -22,6 +23,12 @@ const makeStyles = (): StyleSheet.NamedStyles<{
         section: {
             padding: 16,
             marginBottom: 32,
+        },
+        sectionTablet: {
+            width: '100%',
+            maxWidth: 480,
+            alignSelf: 'center',
+            paddingTop: 40,
         },
         topDivider: {
             marginTop: 40,
@@ -42,12 +49,20 @@ const makeStyles = (): StyleSheet.NamedStyles<{
 export const FixedLengthPasscodeScreen: React.FC = () => {
     const navigation = useNavigation<DrawerNavigationProp<Record<string, undefined>>>();
     const styles = makeStyles();
+    const [dimensions, setDimensions] = useState({ window: Dimensions.get('window') });
     const [passcode, setPasscode] = useState('');
     const [passcodeErrorText, setPasscodeErrorText] = useState('');
     const [isLoading, setIsLoading] = useState(false);
     const [passcodeSubmitted, setPasscodeSubmitted] = useState(false);
     const [passcodeSuccess, setPasscodeSuccess] = useState(false);
     const [shouldValidate, setShouldValidate] = useState(false);
+
+    useEffect(() => {
+        const subscription = Dimensions.addEventListener('change', ({ window }) => {
+            setDimensions({ window });
+        });
+        return (): void => subscription?.remove();
+    });
 
     const toggleMenu = (): void => {
         navigation.openDrawer();
@@ -113,7 +128,7 @@ export const FixedLengthPasscodeScreen: React.FC = () => {
             />
             <SafeAreaView>
                 <ScrollView>
-                    <View style={styles.section}>
+                    <View style={[styles.section, dimensions.window.width < 600 ? {} : styles.sectionTablet]}>
                         <Body1>
                             Please enter the <Body1 font={'medium'}>six-digit passcode</Body1> we just send to you. The
                             passcode is valid for 15 minutes.

--- a/examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode.tsx
+++ b/examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode.tsx
@@ -104,7 +104,7 @@ export const FixedLengthPasscodeScreen: React.FC = () => {
     };
 
     return (
-        <View style={{ flex: 1 }}>
+        <View style={{ flex: 1, backgroundColor: Colors.white[50] }}>
             <Header
                 title={'Fixed Length Passcode'}
                 navigation={{

--- a/examples/forms-and-validation/fixed-length-passcode/__snapshots__/fixed-length-passcode.test.tsx.snap
+++ b/examples/forms-and-validation/fixed-length-passcode/__snapshots__/fixed-length-passcode.test.tsx.snap
@@ -256,7 +256,7 @@ exports[`Fixed Length Passcode Tests renders the screen 1`] = `
                 Object {
                   "marginBottom": 32,
                   "marginHorizontal": -16,
-                  "marginTop": 24,
+                  "marginTop": 40,
                 },
               ]
             }

--- a/examples/forms-and-validation/fixed-length-passcode/__snapshots__/fixed-length-passcode.test.tsx.snap
+++ b/examples/forms-and-validation/fixed-length-passcode/__snapshots__/fixed-length-passcode.test.tsx.snap
@@ -133,10 +133,18 @@ exports[`Fixed Length Passcode Tests renders the screen 1`] = `
       <View>
         <View
           style={
-            Object {
-              "marginBottom": 32,
-              "padding": 16,
-            }
+            Array [
+              Object {
+                "marginBottom": 32,
+                "padding": 16,
+              },
+              Object {
+                "alignSelf": "center",
+                "maxWidth": 480,
+                "paddingTop": 40,
+                "width": "100%",
+              },
+            ]
           }
         >
           <Text

--- a/examples/forms-and-validation/fixed-length-passcode/__snapshots__/fixed-length-passcode.test.tsx.snap
+++ b/examples/forms-and-validation/fixed-length-passcode/__snapshots__/fixed-length-passcode.test.tsx.snap
@@ -1,0 +1,565 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Fixed Length Passcode Tests renders the screen 1`] = `
+<View
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <RCTSafeAreaView
+    accessible={true}
+    emulateUnlessSupported={true}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "backgroundColor": "#6200ee",
+        "elevation": 0,
+        "height": 132,
+        "shadowColor": "rgba(0, 0, 0, 0.3)",
+        "shadowOffset": Object {
+          "height": 1,
+          "width": 0,
+        },
+        "shadowOpacity": 1,
+        "shadowRadius": 2,
+        "width": "100%",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "flex": 1,
+          "flexDirection": "row",
+          "minHeight": 112,
+          "paddingBottom": 32,
+          "paddingHorizontal": 16,
+          "paddingVertical": 32,
+        }
+      }
+    >
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "height": 80,
+            "margin": -16,
+            "marginRight": 24,
+            "opacity": 1,
+            "padding": 16,
+            "width": 80,
+          }
+        }
+        testID="header-navigation"
+      >
+        <Text />
+      </View>
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "flexDirection": "column",
+            "justifyContent": "flex-end",
+            "marginRight": 0,
+            "marginTop": 0,
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "flex": 0,
+              "justifyContent": "center",
+            }
+          }
+        >
+          <Text
+            ellipsizeMode="tail"
+            numberOfLines={1}
+            style={
+              Object {
+                "color": "white",
+                "fontFamily": "System",
+                "fontSize": 20,
+                "lineHeight": 20,
+                "textAlign": "auto",
+                "writingDirection": "ltr",
+              }
+            }
+            testID="header-title"
+          >
+            Fixed Length Passcode
+          </Text>
+        </View>
+      </View>
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "height": 112,
+              "position": "absolute",
+              "right": 8,
+            },
+            undefined,
+          ]
+        }
+      />
+    </View>
+  </RCTSafeAreaView>
+  <RCTSafeAreaView
+    emulateUnlessSupported={true}
+  >
+    <RCTScrollView>
+      <View>
+        <View
+          style={
+            Object {
+              "marginBottom": 32,
+              "padding": 16,
+            }
+          }
+        >
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#000000",
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
+                Object {},
+                Object {
+                  "fontFamily": "System",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                },
+                Object {},
+                undefined,
+                undefined,
+              ]
+            }
+          >
+            Please enter the 
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#000000",
+                  },
+                  Object {
+                    "writingDirection": "ltr",
+                  },
+                  Object {},
+                  Object {
+                    "fontFamily": "System",
+                    "fontSize": 16,
+                    "fontWeight": "400",
+                    "letterSpacing": 0,
+                  },
+                  Object {
+                    "fontFamily": "System",
+                    "fontWeight": "500",
+                  },
+                  undefined,
+                  undefined,
+                ]
+              }
+            >
+              six-digit passcode
+            </Text>
+             we just send to you. The passcode is valid for 15 minutes.
+          </Text>
+          <Text
+            style={
+              Array [
+                Object {
+                  "color": "#000000",
+                },
+                Object {
+                  "writingDirection": "ltr",
+                },
+                Object {},
+                Object {
+                  "fontFamily": "System",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                },
+                Object {},
+                undefined,
+                Object {
+                  "marginTop": 8,
+                },
+              ]
+            }
+          >
+            For the purpose of this demonstration, passcode 
+            <Text
+              style={
+                Array [
+                  Object {
+                    "color": "#000000",
+                  },
+                  Object {
+                    "writingDirection": "ltr",
+                  },
+                  Object {},
+                  Object {
+                    "fontFamily": "System",
+                    "fontSize": 16,
+                    "fontWeight": "400",
+                    "letterSpacing": 0,
+                  },
+                  Object {
+                    "fontFamily": "System",
+                    "fontWeight": "500",
+                  },
+                  undefined,
+                  undefined,
+                ]
+              }
+            >
+              123456
+            </Text>
+             will pass. Any other 6 digit passcode will fail.
+          </Text>
+          <View
+            style={
+              Array [
+                Object {
+                  "backgroundColor": "rgba(0, 0, 0, 0.12)",
+                  "height": 0.5,
+                },
+                undefined,
+                Object {
+                  "marginBottom": 32,
+                  "marginHorizontal": -16,
+                  "marginTop": 24,
+                },
+              ]
+            }
+          />
+          <View
+            style={
+              Object {
+                "marginBottom": 24.5,
+              }
+            }
+          >
+            <View>
+              <View
+                style={
+                  Array [
+                    Object {
+                      "backgroundColor": "rgb(231, 231, 231)",
+                      "borderTopLeftRadius": 4,
+                      "borderTopRightRadius": 4,
+                    },
+                    Object {
+                      "backgroundColor": "#f7f8f8",
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "backgroundColor": "#d5d8da",
+                      "bottom": 0,
+                      "height": 2,
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "transform": Array [
+                        Object {
+                          "scaleY": 0.5,
+                        },
+                      ],
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "paddingBottom": 0,
+                        "paddingTop": 0,
+                      },
+                      Object {
+                        "minHeight": 70,
+                      },
+                    ]
+                  }
+                >
+                  <View
+                    pointerEvents="none"
+                    style={
+                      Object {
+                        "bottom": 0,
+                        "left": 0,
+                        "opacity": 1,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                        "transform": Array [
+                          Object {
+                            "translateX": 0,
+                          },
+                        ],
+                      }
+                    }
+                  >
+                    <Text
+                      numberOfLines={1}
+                      onLayout={[Function]}
+                      style={
+                        Object {
+                          "color": "#6200ee",
+                          "fontFamily": "System",
+                          "fontSize": 18,
+                          "fontWeight": undefined,
+                          "left": 0,
+                          "opacity": 0,
+                          "paddingLeft": 12,
+                          "paddingRight": 12,
+                          "position": "absolute",
+                          "textAlign": "left",
+                          "top": 35,
+                          "transform": Array [
+                            Object {
+                              "translateX": 0,
+                            },
+                            Object {
+                              "translateY": 0,
+                            },
+                            Object {
+                              "scale": 1,
+                            },
+                          ],
+                          "writingDirection": "ltr",
+                        }
+                      }
+                    >
+                      Passcode *
+                    </Text>
+                    <Text
+                      numberOfLines={1}
+                      style={
+                        Object {
+                          "color": "rgba(0, 0, 0, 0.54)",
+                          "fontFamily": "System",
+                          "fontSize": 18,
+                          "fontWeight": undefined,
+                          "left": 0,
+                          "opacity": 0,
+                          "paddingLeft": 12,
+                          "paddingRight": 12,
+                          "position": "absolute",
+                          "textAlign": "left",
+                          "top": 35,
+                          "transform": Array [
+                            Object {
+                              "translateX": 0,
+                            },
+                            Object {
+                              "translateY": 0,
+                            },
+                            Object {
+                              "scale": 1,
+                            },
+                          ],
+                          "writingDirection": "ltr",
+                        }
+                      }
+                    >
+                      Passcode *
+                    </Text>
+                  </View>
+                  <TextInput
+                    allowFontScaling={true}
+                    autoCapitalize="none"
+                    editable={true}
+                    keyboardType="numeric"
+                    maxLength={6}
+                    multiline={false}
+                    onBlur={[Function]}
+                    onChangeText={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    placeholderTextColor="rgba(0, 0, 0, 0.54)"
+                    rejectResponderTermination={true}
+                    returnKeyType="next"
+                    selectionColor="#6200ee"
+                    style={
+                      Array [
+                        Object {
+                          "flexGrow": 1,
+                          "margin": 0,
+                          "zIndex": 1,
+                        },
+                        Object {
+                          "paddingLeft": 12,
+                          "paddingRight": 12,
+                        },
+                        Object {
+                          "height": 70,
+                        },
+                        Object {
+                          "paddingBottom": 4,
+                          "paddingTop": 24,
+                        },
+                        Object {
+                          "color": "#000000",
+                          "fontFamily": "System",
+                          "fontSize": 18,
+                          "fontWeight": undefined,
+                          "textAlign": "left",
+                          "textAlignVertical": "center",
+                        },
+                        Object {
+                          "marginRight": 36,
+                          "paddingRight": 8,
+                        },
+                      ]
+                    }
+                    textContentType="none"
+                    underlineColorAndroid="transparent"
+                    value=""
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              Object {
+                "backgroundColor": "transparent",
+                "borderColor": "rgba(0, 0, 0, 0.29)",
+                "borderRadius": 4,
+                "borderStyle": "solid",
+                "borderWidth": 0.5,
+                "elevation": 0,
+                "marginTop": 16,
+                "minWidth": 64,
+              }
+            }
+          >
+            <View
+              accessibilityRole="button"
+              accessibilityState={
+                Object {
+                  "disabled": undefined,
+                }
+              }
+              accessible={true}
+              focusable={true}
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Array [
+                  Object {
+                    "overflow": "hidden",
+                  },
+                  Object {
+                    "borderRadius": 4,
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                <View
+                  style={
+                    Object {
+                      "marginLeft": 12,
+                      "marginRight": -4,
+                    }
+                  }
+                >
+                  <Text />
+                </View>
+                <Text
+                  numberOfLines={1}
+                  selectable={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": "#000000",
+                        "fontFamily": "System",
+                        "fontWeight": "400",
+                      },
+                      Object {
+                        "textAlign": "left",
+                      },
+                      Array [
+                        Object {
+                          "letterSpacing": 1,
+                          "marginHorizontal": 16,
+                          "marginVertical": 9,
+                          "textAlign": "center",
+                        },
+                        undefined,
+                        Object {
+                          "textTransform": "uppercase",
+                        },
+                        Object {
+                          "color": "#6200ee",
+                          "fontFamily": "System",
+                          "fontWeight": "500",
+                        },
+                        Object {
+                          "fontFamily": "System",
+                          "fontWeight": "500",
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  Reset Form
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+  </RCTSafeAreaView>
+</View>
+`;

--- a/examples/forms-and-validation/fixed-length-passcode/__snapshots__/fixed-length-passcode.test.tsx.snap
+++ b/examples/forms-and-validation/fixed-length-passcode/__snapshots__/fixed-length-passcode.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Fixed Length Passcode Tests renders the screen 1`] = `
 <View
   style={
     Object {
+      "backgroundColor": "#ffffff",
       "flex": 1,
     }
   }

--- a/examples/forms-and-validation/fixed-length-passcode/__snapshots__/fixed-length-passcode.test.tsx.snap
+++ b/examples/forms-and-validation/fixed-length-passcode/__snapshots__/fixed-length-passcode.test.tsx.snap
@@ -409,7 +409,7 @@ exports[`Fixed Length Passcode Tests renders the screen 1`] = `
                     placeholder=""
                     placeholderTextColor="rgba(0, 0, 0, 0.54)"
                     rejectResponderTermination={true}
-                    returnKeyType="next"
+                    returnKeyType="done"
                     selectionColor="#6200ee"
                     style={
                       Array [

--- a/examples/forms-and-validation/fixed-length-passcode/fixed-length-passcode.test.tsx
+++ b/examples/forms-and-validation/fixed-length-passcode/fixed-length-passcode.test.tsx
@@ -11,4 +11,24 @@ describe('Fixed Length Passcode Tests', () => {
         const tree = renderer.create(<FixedLengthPasscodeScreen />).toJSON();
         expect(tree).toMatchSnapshot();
     });
+
+    // it('should display error on blur when passcode length is less than six', () => {
+
+    // });
+
+    // it('should verify passcode correctly', () => {
+
+    // });
+
+    // it('should fail passcode verification correctly', () => {
+
+    // });
+
+    // it('should disable passcode input field after entering a valid passcode', () => {
+
+    // });
+
+    // it('should reset form on "reset form" button press', () => {
+
+    // });
 });

--- a/examples/forms-and-validation/fixed-length-passcode/fixed-length-passcode.test.tsx
+++ b/examples/forms-and-validation/fixed-length-passcode/fixed-length-passcode.test.tsx
@@ -11,24 +11,4 @@ describe('Fixed Length Passcode Tests', () => {
         const tree = renderer.create(<FixedLengthPasscodeScreen />).toJSON();
         expect(tree).toMatchSnapshot();
     });
-
-    // it('should display error on blur when passcode length is less than six', () => {
-
-    // });
-
-    // it('should verify passcode correctly', () => {
-
-    // });
-
-    // it('should fail passcode verification correctly', () => {
-
-    // });
-
-    // it('should disable passcode input field after entering a valid passcode', () => {
-
-    // });
-
-    // it('should reset form on "reset form" button press', () => {
-
-    // });
 });

--- a/examples/forms-and-validation/fixed-length-passcode/fixed-length-passcode.tsx
+++ b/examples/forms-and-validation/fixed-length-passcode/fixed-length-passcode.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { FixedLengthPasscodeScreen } from './FixedLengthPasscode';
+
+jest.mock('@react-navigation/native', () => ({
+    useNavigation: (): any => ({ openDrawer: jest.fn(() => true) }),
+}));
+
+describe('Fixed Length Passcode Tests', () => {
+    it('renders the screen', () => {
+        const tree = renderer.create(<FixedLengthPasscodeScreen />).toJSON();
+        expect(tree).toMatchSnapshot();
+    });
+});

--- a/examples/forms-and-validation/password-validation/PasswordValidation.tsx
+++ b/examples/forms-and-validation/password-validation/PasswordValidation.tsx
@@ -30,7 +30,7 @@ const makeStyles = (): StyleSheet.NamedStyles<{
             marginBottom: 32,
         },
         topDivider: {
-            marginTop: 24,
+            marginTop: 40,
             marginBottom: 32,
             marginHorizontal: -16,
         },

--- a/examples/forms-and-validation/password-validation/PasswordValidation.tsx
+++ b/examples/forms-and-validation/password-validation/PasswordValidation.tsx
@@ -7,6 +7,7 @@ import { DrawerNavigationProp } from '@react-navigation/drawer';
 import { TextInput } from '../shared/TextInput';
 import { PasswordRequirement, passwordRequirements, PasswordRequirements } from './PasswordRequirements';
 import { Button, Divider } from 'react-native-paper';
+import * as Colors from '@pxblue/colors';
 
 const MenuIcon = wrapIcon({ IconClass: MaterialIcons, name: 'menu' });
 
@@ -183,7 +184,7 @@ export const PasswordValidationScreen: React.FC = () => {
     );
 
     return (
-        <View style={{ flex: 1 }}>
+        <View style={{ flex: 1, backgroundColor: Colors.white[50] }}>
             <Header
                 title={'Password Validation'}
                 navigation={{

--- a/examples/forms-and-validation/password-validation/PasswordValidation.tsx
+++ b/examples/forms-and-validation/password-validation/PasswordValidation.tsx
@@ -84,53 +84,47 @@ export const PasswordValidationScreen: React.FC = () => {
         navigation.openDrawer();
     };
 
-    const validateCurrentPassword = useCallback(
-        (value: string): void => {
-            const tempCurrentPassword = value;
-            let tempCurrentPasswordError = '';
-            if (!tempCurrentPassword.trim()) {
-                tempCurrentPasswordError = 'required';
-            }
-            setCurrentPasswordErrorText(tempCurrentPasswordError);
-        },
-        [setCurrentPasswordErrorText]
-    );
+    const validateCurrentPassword = useCallback((value: string): void => {
+        const tempCurrentPassword = value;
+        let tempCurrentPasswordError = '';
+        if (!tempCurrentPassword.trim()) {
+            tempCurrentPasswordError = 'required';
+        }
+        setCurrentPasswordErrorText(tempCurrentPasswordError);
+    }, []);
 
     const onCurrentPasswordChange = useCallback(
         (text: string) => {
             setCurrentPassword(text);
             validateCurrentPassword(text);
         },
-        [setCurrentPassword, validateCurrentPassword]
+        [validateCurrentPassword]
     );
 
     const onCurrentPasswordBlur = useCallback((): void => {
         validateCurrentPassword(currentPassword);
     }, [validateCurrentPassword, currentPassword]);
 
-    const validateNewPassword = useCallback(
-        (value: string): void => {
-            const tempNewPassword = value;
-            let tempNewPasswordError = false;
-            setHasNewPasswordError(false);
+    const validateNewPassword = useCallback((value: string): void => {
+        const tempNewPassword = value;
+        let tempNewPasswordError = false;
+        setHasNewPasswordError(false);
 
-            passwordRequirements.forEach((requirement: PasswordRequirement) => {
-                if (!requirement.regex.test(tempNewPassword)) {
-                    tempNewPasswordError = true;
-                }
-            });
+        passwordRequirements.forEach((requirement: PasswordRequirement) => {
+            if (!requirement.regex.test(tempNewPassword)) {
+                tempNewPasswordError = true;
+            }
+        });
 
-            setHasNewPasswordError(tempNewPasswordError);
-        },
-        [setHasNewPasswordError]
-    );
+        setHasNewPasswordError(tempNewPasswordError);
+    }, []);
 
     const onNewPasswordChange = useCallback(
         (text: string) => {
             setNewPassword(text);
             validateNewPassword(text);
         },
-        [setNewPassword, validateNewPassword]
+        [validateNewPassword]
     );
 
     const onNewPasswordBlur = useCallback((): void => {
@@ -148,7 +142,7 @@ export const PasswordValidationScreen: React.FC = () => {
             }
             setConfirmPasswordErrorText(tempConfirmPasswordError);
         },
-        [setConfirmPasswordErrorText, newPassword]
+        [newPassword]
     );
 
     const onConfirmPasswordChange = useCallback(
@@ -156,7 +150,7 @@ export const PasswordValidationScreen: React.FC = () => {
             setConfirmPassword(text);
             validateConfirmPassword(text);
         },
-        [setConfirmPassword, validateConfirmPassword]
+        [validateConfirmPassword]
     );
 
     const onConfirmPasswordBlur = useCallback((): void => {

--- a/examples/forms-and-validation/password-validation/PasswordValidation.tsx
+++ b/examples/forms-and-validation/password-validation/PasswordValidation.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { Body1, Header, wrapIcon } from '@pxblue/react-native-components';
-import { View, StyleSheet, ScrollView, ViewStyle, TextStyle, SafeAreaView } from 'react-native';
+import { View, StyleSheet, ScrollView, ViewStyle, SafeAreaView } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useNavigation } from '@react-navigation/native';
 import { DrawerNavigationProp } from '@react-navigation/drawer';
@@ -14,12 +14,12 @@ const MenuIcon = wrapIcon({ IconClass: MaterialIcons, name: 'menu' });
 const makeStyles = (): StyleSheet.NamedStyles<{
     section: ViewStyle;
     topDivider: ViewStyle;
-    currentPasswordFormFieldWrapper: TextStyle;
-    currentPasswordErrorFormFieldWrapper: TextStyle;
-    newPasswordFormFieldWrapper: TextStyle;
+    currentPasswordFormFieldWrapper: ViewStyle;
+    currentPasswordErrorFormFieldWrapper: ViewStyle;
+    newPasswordFormFieldWrapper: ViewStyle;
     passwordRequirements: ViewStyle;
-    confirmPasswordFormFieldWrapper: TextStyle;
-    confirmPasswordErrorFormFieldWrapper: TextStyle;
+    confirmPasswordFormFieldWrapper: ViewStyle;
+    confirmPasswordErrorFormFieldWrapper: ViewStyle;
     buttonContainer: ViewStyle;
     bottomDivider: ViewStyle;
     submitButton: ViewStyle;

--- a/examples/forms-and-validation/password-validation/__snapshots__/password-validation.test.tsx.snap
+++ b/examples/forms-and-validation/password-validation/__snapshots__/password-validation.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Password Validation Tests renders the screen 1`] = `
 <View
   style={
     Object {
+      "backgroundColor": "#ffffff",
       "flex": 1,
     }
   }

--- a/examples/forms-and-validation/password-validation/__snapshots__/password-validation.test.tsx.snap
+++ b/examples/forms-and-validation/password-validation/__snapshots__/password-validation.test.tsx.snap
@@ -174,7 +174,7 @@ exports[`Password Validation Tests renders the screen 1`] = `
                 Object {
                   "marginBottom": 32,
                   "marginHorizontal": -16,
-                  "marginTop": 24,
+                  "marginTop": 40,
                 },
               ]
             }

--- a/examples/forms-and-validation/shared/TextInput.tsx
+++ b/examples/forms-and-validation/shared/TextInput.tsx
@@ -93,14 +93,14 @@ const TextInputRender: React.ForwardRefRenderFunction<{}, TextInputRenderProps> 
                 selectionColor={selectionColor}
                 right={
                     rightIcon &&
-                    rightIcon.name && (
+                    rightIcon.name ? (
                         <PaperTextInput.Icon
                             name={rightIcon.name}
                             forceTextInputFocus={false}
                             onPress={rightIcon?.onPress}
                             color={rightIcon?.color}
                         />
-                    )
+                    ) : rightIcon
                 }
                 error={error}
                 {...inputProps}

--- a/examples/forms-and-validation/shared/TextInput.tsx
+++ b/examples/forms-and-validation/shared/TextInput.tsx
@@ -40,6 +40,7 @@ export type TextInputRenderProps = Omit<TextInputProps, 'theme'> & {
     helperStyles?: ViewStyle;
     helperTextRight?: string;
     rightIcon?: InputIconType;
+    rightText?: InputTextType;
     rightIconOnPress?: () => void;
     theme?: ReactNativePaper.Theme;
     testID?: string;
@@ -49,6 +50,11 @@ export type InputIconType = {
     name?: string;
     color?: string;
     onPress?: () => void;
+};
+
+export type InputTextType = {
+    text?: string;
+    style?: TextStyle;
 };
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -66,6 +72,7 @@ const TextInputRender: React.ForwardRefRenderFunction<{}, TextInputRenderProps> 
         helperText,
         helperTextRight,
         rightIcon,
+        rightText,
         theme: customTheme,
         ...inputProps
     } = props;
@@ -92,15 +99,18 @@ const TextInputRender: React.ForwardRefRenderFunction<{}, TextInputRenderProps> 
                 underlineColor={Colors.gray['100']}
                 selectionColor={selectionColor}
                 right={
-                    rightIcon &&
-                    rightIcon.name ? (
+                    rightIcon && rightIcon.name ? (
                         <PaperTextInput.Icon
                             name={rightIcon.name}
                             forceTextInputFocus={false}
                             onPress={rightIcon?.onPress}
                             color={rightIcon?.color}
                         />
-                    ) : rightIcon
+                    ) : rightText && rightText.text ? (
+                        <PaperTextInput.Affix text={rightText.text} textStyle={rightText.style} />
+                    ) : (
+                        <></>
+                    )
                 }
                 error={error}
                 {...inputProps}

--- a/router/drawer.tsx
+++ b/router/drawer.tsx
@@ -68,6 +68,11 @@ export const NavigationDrawer: React.FC<DrawerContentComponentProps> = (props) =
                                     itemID: ROUTES.PASSWORD_VALIDATION.name,
                                     onPress: (): void => goTo(ROUTES.PASSWORD_VALIDATION.route),
                                 },
+                                {
+                                    title: ROUTES.FIXED_LENGTH_PASSCODE.name,
+                                    itemID: ROUTES.FIXED_LENGTH_PASSCODE.name,
+                                    onPress: (): void => goTo(ROUTES.FIXED_LENGTH_PASSCODE.route),
+                                },
                             ],
                         },
                         // {

--- a/router/index.tsx
+++ b/router/index.tsx
@@ -17,6 +17,7 @@ import { MultiselectListScreen } from '../examples/multiselect-list/MultiselectL
 import { SortableListScreen } from '../examples/sortable-list/SortableList';
 import { FormValidationScreen } from '../examples/form-validation/FormValidation';
 import { PasswordValidationScreen } from '../examples/forms-and-validation/password-validation/PasswordValidation';
+import { FixedLengthPasscodeScreen } from '../examples/forms-and-validation/fixed-length-passcode/FixedLengthPasscode';
 
 const Drawer = createDrawerNavigator();
 
@@ -32,6 +33,7 @@ export const MyDrawer: React.FC = () => (
         <Drawer.Screen name={ROUTES.LOADING_STATES.route} component={LoadingStatesScreen} />
         <Drawer.Screen name={ROUTES.FORM_VALIDATION.route} component={FormValidationScreen} />
         <Drawer.Screen name={ROUTES.PASSWORD_VALIDATION.route} component={PasswordValidationScreen} />
+        <Drawer.Screen name={ROUTES.FIXED_LENGTH_PASSCODE.route} component={FixedLengthPasscodeScreen} />
         <Drawer.Screen name={ROUTES.I18N.route}>
             {(): JSX.Element => <Placeholder title={ROUTES.I18N.name} />}
         </Drawer.Screen>

--- a/router/routes.tsx
+++ b/router/routes.tsx
@@ -6,6 +6,7 @@ export const ROUTES = {
     FORM_VALIDATION: { name: 'Form Validation', route: 'form-validation' },
     FORMS_AND_VALIDATION: { name: 'Forms and Validation' },
     PASSWORD_VALIDATION: { name: 'Password', route: 'password' },
+    FIXED_LENGTH_PASSCODE: { name: 'Fixed Length Passcode', route: 'fixed-length-passcode' },
     I18N: { name: 'Internationalization', route: 'internationalization' },
     ACTION_LIST: { name: 'Action List', route: 'action-list' },
     DATA_LIST: { name: 'Data List', route: 'data-list' },


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes PXBLUE-2425.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add Fixed Length Passcode design pattern example
- Minor style updates to the Password Validation example (background color, margin above top divider)

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![Simulator Screen Shot - iPhone 12 - 2021-08-19 at 07 09 05](https://user-images.githubusercontent.com/13989985/130059252-8bddff7f-31e7-4aca-bc7a-4d771887634d.png)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- clone repo
- run `yarn && yarn start`
- navigate to Forms and Validation > Fixed Length Passcode
- run through the scenarios defined in Figma: https://www.figma.com/file/ZzZJSoGjeKdrYct57EMPS0/Design-Patterns-Mono-Repo-Redesign?node-id=536%3A98570

#### Additional Context:
The react-native-paper TextInput component only takes text or an icon as right content so I cannot use the ActivityIndicator component to show an active loading state. I set the right content to be "Verifying...". We may want to update this behavior, but it is not a bug.